### PR TITLE
Add precision on tests using toBeCloseTo.

### DIFF
--- a/test/imports.spec.ts
+++ b/test/imports.spec.ts
@@ -3,8 +3,14 @@ import { getWasmInstanceSync } from "./utils/utils";
 
 let instance: WebAssembly.Instance;
 const TwoPI = 2 * Math.PI;
-const precision = 10; // Number of digits of precision for toBeCloseTo
-const precisionValue = parseFloat(`1.0e-${precision}`);
+
+// As per [Wikipedia](https://en.wikipedia.org/wiki/IEEE_floating_point)
+// the following define the number of decimal digits of precision for
+// float64(15.95) and float32(7.22) reduced by 2 for rounding.
+const float64Precision = 13;
+const float64PrecisionValue = parseFloat(`1.0e-${float64Precision}`);
+const float32Precision = 5;
+const float32PrecisionValue = parseFloat(`1.0e-${float32Precision}`);
 
 test("it should compile without error", () => {
     instance = getWasmInstanceSync(
@@ -14,14 +20,24 @@ test("it should compile without error", () => {
     expect(instance).toBeDefined();
 })
 
-test("precision", () => {
+test("of float64Precision", () => {
     const value: number = Math.random() * TwoPI;
     const expected: number = Math.sin(value);
-    const expectedFail: number = expected + precisionValue;
+    const expectedFail: number = expected + float64PrecisionValue;
 
     const result: number = instance.exports.sin(value);
-    expect(result).toBeCloseTo(expected, precision);
-    expect(result).not.toBeCloseTo(expectedFail, precision);
+    expect(result).toBeCloseTo(expected, float64Precision);
+    expect(result).not.toBeCloseTo(expectedFail, float64Precision);
+});
+
+test("of float32Precision", () => {
+    const value: number = Math.random();
+    const expected: number = Math.fround(Math.abs(value)); //WASM abs is 32bit float
+    const expectedFail: number = expected + float32PrecisionValue;
+
+    const result: number = instance.exports.abs(value);
+    expect(result).toBeCloseTo(expected, float32Precision);
+    expect(result).not.toBeCloseTo(expectedFail, float32Precision);
 });
 
 test("it should import sin function from javascript", () => {
@@ -29,7 +45,7 @@ test("it should import sin function from javascript", () => {
     const expected: number = Math.sin(value);
 
     const result: number = instance.exports.sin(value);
-    expect(result).toBeCloseTo(expected, precision);
+    expect(result).toBeCloseTo(expected, float64Precision);
 });
 
 test("it should import cos function from javascript", () => {
@@ -37,7 +53,7 @@ test("it should import cos function from javascript", () => {
     const expected: number = Math.cos(value);
 
     const result: number = instance.exports.cos(value);
-    expect(result).toBeCloseTo(expected, precision);
+    expect(result).toBeCloseTo(expected, float64Precision);
 });
 
 test("it should import tan function from javascript", () => {
@@ -45,7 +61,7 @@ test("it should import tan function from javascript", () => {
     const expected: number = Math.tan(value);
 
     const result: number = instance.exports.tan(value);
-    expect(result).toBeCloseTo(expected, precision);
+    expect(result).toBeCloseTo(expected, float64Precision);
 });
 
 test("it should import abs function from javascript", () => {
@@ -53,5 +69,5 @@ test("it should import abs function from javascript", () => {
     const expected: number = Math.fround(Math.abs(value)); //WASM abs is 32bit float
 
     const result: number = instance.exports.abs(value);
-    expect(result).toBeCloseTo(expected, precision);
+    expect(result).toBeCloseTo(expected, float32Precision);
 });

--- a/test/imports.spec.ts
+++ b/test/imports.spec.ts
@@ -3,6 +3,8 @@ import { getWasmInstanceSync } from "./utils/utils";
 
 let instance: WebAssembly.Instance;
 const TwoPI = 2 * Math.PI;
+const precision = 10; // Number of digits of precision for toBeCloseTo
+const precisionValue = parseFloat(`1.0e-${precision}`);
 
 test("it should compile without error", () => {
     instance = getWasmInstanceSync(
@@ -12,12 +14,22 @@ test("it should compile without error", () => {
     expect(instance).toBeDefined();
 })
 
+test("precision", () => {
+    const value: number = Math.random() * TwoPI;
+    const expected: number = Math.sin(value);
+    const expectedFail: number = expected + precisionValue;
+
+    const result: number = instance.exports.sin(value);
+    expect(result).toBeCloseTo(expected, precision);
+    expect(result).not.toBeCloseTo(expectedFail, precision);
+});
+
 test("it should import sin function from javascript", () => {
     const value: number = Math.random() * TwoPI;
     const expected: number = Math.sin(value);
 
     const result: number = instance.exports.sin(value);
-    expect(result).toBeCloseTo(expected);
+    expect(result).toBeCloseTo(expected, precision);
 });
 
 test("it should import cos function from javascript", () => {
@@ -25,7 +37,7 @@ test("it should import cos function from javascript", () => {
     const expected: number = Math.cos(value);
 
     const result: number = instance.exports.cos(value);
-    expect(result).toBeCloseTo(expected);
+    expect(result).toBeCloseTo(expected, precision);
 });
 
 test("it should import tan function from javascript", () => {
@@ -33,7 +45,7 @@ test("it should import tan function from javascript", () => {
     const expected: number = Math.tan(value);
 
     const result: number = instance.exports.tan(value);
-    expect(result).toBeCloseTo(expected);
+    expect(result).toBeCloseTo(expected, precision);
 });
 
 test("it should import abs function from javascript", () => {
@@ -41,5 +53,5 @@ test("it should import abs function from javascript", () => {
     const expected: number = Math.fround(Math.abs(value)); //WASM abs is 32bit float
 
     const result: number = instance.exports.abs(value);
-    expect(result).toBeCloseTo(expected);
+    expect(result).toBeCloseTo(expected, precision);
 });


### PR DESCRIPTION
According to [this](https://facebook.github.io/jest/docs/expect.html#tobeclosetonumber-numdigits)
the default precision is 2 that seems to few, so using 10.

Also, added the `precision` test to validate the test.