### PR TITLE
Fixed a couple of dev issues on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "install:node-v8": "ts-node ./scripts/install-node-v8.ts",
     "build": "tsc -p ./src && tsc lib/tc.ts",
     "watch-build": "tsc -w -p ./src && tsc -w -p ./lib",
-    "test": "./node-v8/bin/node ./node_modules/jest/bin/jest.js ",
-    "watch-test": "./node-v8/bin/node ./node_modules/jest/bin/jest.js --watch"
+    "test": "ts-node ./scripts/run-node-v8.ts ./node_modules/jest/bin/jest.js",
+    "watch-test": "ts-node ./scripts/run-node-v8.ts ./node_modules/jest/bin/jest.js --watch"
   },
   "jest": {
     "globals": {

--- a/scripts/install-node-v8.ts
+++ b/scripts/install-node-v8.ts
@@ -37,8 +37,8 @@ request.get(nightlyBaseUrl + "index.json", function (error, response, body: stri
 });
 
 function generateDownloadUrl(nightlyInfo: Nightly[]): string {
-    //Just take first entry, assuming it is the latest.
-    let latest: Nightly = nightlyInfo[0];
+    //Just take the 'second' entry, assuming it is the latest 'completely uploaded'.
+    let latest: Nightly = nightlyInfo[1];
     fileName = "node-" + latest.version + getPlatform();
     return nightlyBaseUrl + latest.version + "/" + fileName;
 }

--- a/scripts/install-node-v8.ts
+++ b/scripts/install-node-v8.ts
@@ -79,7 +79,11 @@ function startDownload(url) {
 }
 
 function installWindows() {
-    exec(`7z x ${DOWNLOAD_NAME}`, (error, stdout, stderr) => {
+    const _7zDefaultPath = path.join(process.env.ProgramFiles, '7-Zip', '7z.exe');
+    let _7z = '7z';
+    if (fs.existsSync(_7zDefaultPath))
+        _7z = '"' + _7zDefaultPath + '"';
+    exec(`${_7z} x ${DOWNLOAD_NAME}`, (error, stdout, stderr) => {
         if (error) {
             console.error(`exec error: ${error}`);
             return;

--- a/scripts/run-node-v8.ts
+++ b/scripts/run-node-v8.ts
@@ -1,0 +1,19 @@
+// A little wrapper for reliably spawning node-v8 from package.json across platforms.
+
+const spawn = require('child_process').spawn;
+const path = require('path');
+const fs = require('fs');
+
+const dir = path.join(__dirname, '..', 'node-v8');
+
+fs.exists(path.join(dir, 'bin'), exists => {
+    if (!exists) {
+        console.error("node-v8 is not installed. To install it, run: npm run install:node-v8");
+        process.exit(1);
+    }
+    spawn(path.join(dir, 'bin', 'node'), process.argv.slice(2), {
+        stdio: 'inherit'
+    }).on('error', err => {
+        throw err;
+    }).on('close', code => process.exit(code));
+});


### PR DESCRIPTION
install-node-v8 now also searches for 7z in the default install location and, within package.json, a wrapper is used to spawn node-v8 for 'cmd' compatibility.