### PR TITLE
add Assembleash link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# TurboScript 
+# TurboScript
 [![Build Status](https://travis-ci.org/01alchemist/TurboScript.svg?branch=master)](https://travis-ci.org/01alchemist/TurboScript) [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/01alchemist/TurboScript?branch=master&svg=true)]() [![Stories in Ready](https://badge.waffle.io/01alchemist/TurboScript.png?label=ready&title=Ready)](https://waffle.io/01alchemist/TurboScript) [![Greenkeeper badge](https://badges.greenkeeper.io/01alchemist/TurboScript.svg)](https://greenkeeper.io/)
 
-Super charged JavaScript for parallel programming and WebAssembly 
+Super charged JavaScript for parallel programming and WebAssembly
 
 [![Throughput Graph](https://graphs.waffle.io/01alchemist/TurboScript/throughput.svg)](https://waffle.io/01alchemist/TurboScript/metrics/throughput)
 
@@ -15,7 +15,7 @@ Super charged JavaScript for parallel programming and WebAssembly
          \      \           /___         / / / /_/ / , _/ _  / /_/ /
           \______\_________/____"-_____ /_/  \____/_/|_/____/\____/
 </pre>
-  
+
 TurboScript is an experimental programming language for parallel programming for web which compiles to JavaScript ~~(asm.js)~~ and WebAssembly (targeting post-MVP). The syntax is similar to TypeScript ~~(Hardly trying to fill the gaps)~~ and the compiler is open source and written in TypeScript. TurboScript has zero dependencies.
 
 This is still an experiment and isn't intended for real use yet but we are working towards an MVP release. Please feel free to open issues if it stop working or need a new feature.
@@ -29,7 +29,7 @@ This is still an experiment and isn't intended for real use yet but we are worki
 ```typescript
 var myGlobal:int32 = 1;
 let evaluatedVar:int32 = myGlobal + 1;
-// let is same as var. 
+// let is same as var.
 ```
 
 ### function
@@ -47,7 +47,7 @@ export class Vector3D {
     x:float32;
     y:float32;
     z:float32;
-    
+
     constructor(x:float32, y:float32, z:float32){
         this.x = x;
         this.y = y;
@@ -163,6 +163,7 @@ Documentations can be found at [wiki](../../wiki) (under construction :construct
 # Useful links
 * [Future WebHPC & Parallel Programming with JavaScript](https://dump.01alchemist.com/2016/12/31/future-webhpc-parallel-programming-with-javascript-the-new-era-about-to-begin/)
 * [TurboScript playground](https://01alchemist.com/projects/turboscript/playground/)
+* [Assembleash playground](https://github.com/MaxGraey/Assembleash/#TurboScript)
 
 
 # Credit
@@ -170,6 +171,5 @@ Lexical analysis, Parsing, Checking codes are borrowed from Evan Wallace's thins
 
 # Now enjoy - Wow! this snail is fast
 <a href="http://www.youtube.com/watch?feature=player_embedded&v=w-SDeBoDLTg
-" target="_blank"><img src="https://01alchemist.com/images/Turbo-630x354.jpg" 
+" target="_blank"><img src="https://01alchemist.com/images/Turbo-630x354.jpg"
 alt="Wow! this snail is fast" width="630" height="354" border="10" /></a>
-


### PR DESCRIPTION
Currently if not hyperlink arg '#compile_name' specified default compiler is AssemblyScript because it has wast text format. Since TurboScript became allowing wast I change this behaviour to TurboScript
